### PR TITLE
Run tests using python virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ tests/text_extraction_tests_aassumpcao.py
 fake_gazette.json
 fake_gazette.txt
 
-bin
+tests/bin

--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,35 @@
-IMAGE_NAMESPACE ?= serenata
-IMAGE_NAME ?= querido-diario-toolbox
-IMAGE_TAG ?= latest
-POD_NAME ?= querido-diario-toolbox-testing
-BIN_DIR ?= $(PWD)/bin
+BIN_DIR ?= $(PWD)/tests/bin
+PYTHON_VENV ?= $(PWD)/.venv
 
+run-python-venv=(. $(PYTHON_VENV)/bin/activate && $1)
 
-run-command=(podman run --rm -ti \
-	--volume $(PWD):/mnt/code:rw \
-	--pod $(POD_NAME) \
-	--env PYTHONPATH=/mnt/code \
-	--env POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
-	--env POSTGRES_USER=$(POSTGRES_USER) \
-	--env POSTGRES_DB=$(POSTGRES_DB) \
-	--env POSTGRES_HOST=$(POSTGRES_HOST) \
-	--env POSTGRES_PORT=$(POSTGRES_PORT) \
-	--user=$(UID):$(UID) $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) $1)
+pyenv:
+	python3 -m venv $(PYTHON_VENV)
 
-
-.PHONY: black
-black:
-	podman run --rm -ti --volume $(PWD):/mnt/code:rw \
-		--env PYTHONPATH=/mnt/code \
-		--user=$(UID):$(UID) $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) \
-		black .
-
-.PHONY: build
-build:
-	podman build --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) \
-		-f Dockerfile $(PWD)
-
-.PHONY: destroy
-destroy:
-	podman rmi --force $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
-
-destroy-pod:
-	podman pod rm --force --ignore $(POD_NAME)
-
-create-pod: destroy-pod
-	podman pod create --name $(POD_NAME)
-
-.PHONY: test
-test: create-pod retest
-
-.PHONY: retest
-retest:
-	$(call run-command, python -m unittest -f tests)
-
-
-shell:
-	podman run --rm -ti --volume $(PWD):/mnt/code:rw \
-	--env PYTHONPATH=/mnt/code \
-	--user=$(UID):$(UID) $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) bash
-
-.PHONY: coverage
-coverage: create-pod
-	$(call run-command, coverage erase)
-	$(call run-command, coverage run -m unittest tests)
-	$(call run-command, coverage report -m)
+.PHONY: install-deps
+install-deps:
+	$(call run-python-venv, pip3 install -r requirements.txt)
 
 .PHONY: download-binaries
 download-binaries:
-	#wget https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar
 	mkdir -p $(BIN_DIR)
-	curl -o $(BIN_DIR)/tika-app-1.24.jar  http://archive.apache.org/dist/tika/tika-app-1.24.jar
+	cd $(BIN_DIR) && curl -O https://github.com/tabulapdf/tabula-java/releases/download/v1.0.4/tabula-1.0.4-jar-with-dependencies.jar
+	cd $(BIN_DIR) && curl -O http://archive.apache.org/dist/tika/tika-app-1.24.1.jar
 
 .PHONY: setup
-setup: download-binaries build
+setup: pyenv install-deps download-binaries
+
+.PHONY: black
+black:
+	$(call run-python-venv, black $(PWD))
+
+.PHONY: test
+test:
+	$(call run-python-venv, python -m unittest -f tests)
+
+.PHONY: coverage
+coverage: 
+	$(call run-python-venv, coverage erase)
+	$(call run-python-venv, coverage run -m unittest tests)
+	$(call run-python-venv, coverage report -m)
+

--- a/README.md
+++ b/README.md
@@ -1,34 +1,29 @@
 # querido-diario-toolbox
 
+## Prepare devilment environment
+Before start to code you need to setup the development environment. This 
+project uses python virtual environment to isolate the python libraries. 
+Some Java library (e.g. Apache Tika and Tabula) are also needed. 
+So, to get everything you need,  run:
+
+```
+make setup
+```
+
+This command will create the python virtual environment, install python libraries
+and download the necessary binaries. 
+
+Remember to activate the python env before start your development:
+
+```
+source .venv/bin/activate
+```
+
 ## How to run the tests
 
-In order to run the tests locally you need to install some binaries or container image or both.
-
-## Run tests within container
-
-To run the tests within a container you should install [podman](https://podman.io/) 
-in your machine. It is used to build and run the containers. For that you can 
-run the following commands:
+Once you have your env set up. You can run the tests:
 
 ```
-make build # Build container image
-make test  # Run tests
+make tests
 ```
 
-After you build the container image, you just need to run the `make test` every time
-you want to run the tests. You just need to rerun `make build` if you change the 
-`Dockerfile` of the container image. A container image is used to avoid installing 
-binaries used by the project in the host machine. As well as keeping all the environment 
-equal in all developers's machines.
-
-## Run tests locally
-
-If you do not want to run the tests using containers, you can download the binaries 
-used by the project, mainly jar files, configure the tests and  run them manually.
-There is a makefile target to download the binaries:
-
-```
-make download-binaries
-```
-
-The binaries will be downloaded in the `bin` directory in the root of the repository.

--- a/tests/text_extraction_tests.py
+++ b/tests/text_extraction_tests.py
@@ -9,7 +9,7 @@ from queridodiario_toolbox import Gazette
 class TextExtractionTests(TestCase):
 
     def setUp(self):
-        ROOT = "queridodiario_toolbox/bin"
+        ROOT = "tests/bin"
         self.TIKA_PATH = ROOT + "/tika-app-1.24.1.jar"
         self.TABULA_PATH = ROOT + "/tabula-1.0.4-jar-with-dependencies.jar"
 


### PR DESCRIPTION
Updates the project to run the tests in the host machine removing the
container and podman requirement. Now the project uses python virtual
machines to isolate the python libraries used in the development.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>